### PR TITLE
Implementing a pol0-fit to calculate the baseline.

### DIFF
--- a/analysis.C
+++ b/analysis.C
@@ -129,6 +129,20 @@ float* getBL(TH1F* hWave, float* BL, float t1, float t2){
   return BL;
 }
 
+float* BL_fit(TH1F* hWave, float* BL_chi2, float t1, float t2){
+
+  // TF1 *f_const = new TF1("f_const","[0]",t1,t2);
+  // hWave->Fit("f_const","RN");
+  TF1 *f_const = new TF1("f_const","pol0",t1,t2);
+  hWave->Fit("f_const","RNWQ");
+
+  BL_chi2[0] = f_const->GetParameter(0);
+  BL_chi2[1] = f_const->GetParError(0);
+  BL_chi2[2] = f_const->GetChisquare()/f_const->GetNDF();
+
+  return BL_chi2;
+}
+
 double correction_function(double x){
   return (-142.761 + 0.976471* x ) - (-6498.75 + 2.76626*x - 
     0.000141752*TMath::Power(x,2) + 

--- a/analysis.h
+++ b/analysis.h
@@ -11,6 +11,7 @@ float CDFinvert(TH1F* hWave,float thr);
 float Integrate_50ns(TH1F* hWave, float BL);
 float integral(TH1F* hWave,float t1,float t2,float BL);
 float* getBL(TH1F* hWave, float* BL, float t1, float t2);
+float* BL_fit(TH1F* hWave, float* BL_chi2, float t1, float t2);
 double correction_function(double x);
 
 #endif


### PR DESCRIPTION
The fit is done for the first 75ns and the last 100ns. The fit-value, error and chi2/dof are available in the tree through the variables `BL_lower`, `BL_Chi2_lower` and `BL_RMS_lower` (`BL_upper` etc. for second fit).
The integration of 50ns is now also corrected using the BL value that corresponds to the lower chi2/dof of the two fits.